### PR TITLE
feat: implement discovery ranking score with explainable weights (#3)

### DIFF
--- a/src/app/discovery/page.tsx
+++ b/src/app/discovery/page.tsx
@@ -1,23 +1,67 @@
 import { mockDiscovery } from "@/data/mock-discovery";
 
-function scoreBounty(bounty: typeof mockDiscovery[number]) {
-  const fundedBoost = bounty.fundedPercent >= 80 ? 20 : bounty.fundedPercent / 4;
-  const activityBoost = bounty.claimedCount * 5;
-  const recencyBoost = Math.max(0, 14 - bounty.postedDaysAgo);
-  return fundedBoost + activityBoost + recencyBoost + bounty.reward / 50;
+type DiscoveryBounty = (typeof mockDiscovery)[number];
+
+type ScoredBounty = DiscoveryBounty & {
+  score: number;
+  components: {
+    rewardWeight: number;
+    fundedWeight: number;
+    claimsWeight: number;
+    freshnessWeight: number;
+  };
+};
+
+/**
+ * Bounty ranking strategy:
+ * - rewardWeight: bigger rewards are more attractive for participants
+ *   scaled to 0~40 points using reward / 15.
+ * - fundedWeight: high funding completion means this bounty is near goal/clearer intent.
+ *   weighted with capped linear scale 0~30 points.
+ * - claimsWeight: recent claims indicate active interest, social proof.
+ *   each claim adds 2 points.
+ * - freshnessWeight: newer posts are preferred. Recency decays 1.8pt / day up to 14 days.
+ *   old entries older than 14 days score 0 in this dimension.
+ *
+ * Total score keeps all components bounded so one large value cannot dominate everything.
+ */
+function scoreBounty(bounty: DiscoveryBounty): ScoredBounty {
+  const rewardWeight = Math.min(40, bounty.reward / 15); // e.g. $600 => 40 cap
+  const fundedWeight = (Math.min(100, Math.max(0, bounty.fundedPercent)) / 100) * 30;
+  const claimsWeight = Math.min(20, bounty.claimedCount * 2);
+  const freshnessWeight = Math.max(0, 25 - bounty.postedDaysAgo * 1.8);
+
+  return {
+    ...bounty,
+    score: rewardWeight + fundedWeight + claimsWeight + freshnessWeight,
+    components: {
+      rewardWeight,
+      fundedWeight,
+      claimsWeight,
+      freshnessWeight,
+    },
+  };
 }
 
 export default function DiscoveryPage() {
-  const ranked = [...mockDiscovery]
-    .map((bounty) => ({ ...bounty, score: scoreBounty(bounty) }))
-    .sort((a, b) => b.score - a.score);
+  const ranked = mockDiscovery
+    .map(scoreBounty)
+    .sort((a, b) => {
+      if (a.score !== b.score) {
+        return b.score - a.score;
+      }
+
+      // Deterministic tie-breakers: higher reward first, then newer posted.
+      if (a.reward !== b.reward) return b.reward - a.reward;
+      return a.postedDaysAgo - b.postedDaysAgo;
+    });
 
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-semibold">Discovery Algorithm</h1>
         <p className="text-slate-600">
-          Improve or replace the scoring function to rank bounties by relevance.
+          Ranking by weighted score across reward, funding progress, community claims, and freshness.
         </p>
       </div>
 
@@ -40,19 +84,29 @@ export default function DiscoveryPage() {
                 <div className="text-xl font-bold">${bounty.reward}</div>
               </div>
             </div>
-            <div className="mt-4 grid grid-cols-3 gap-3 text-xs text-slate-500">
-              <div>
+
+            <div className="mt-4 grid gap-2 text-xs text-slate-600 sm:grid-cols-2 lg:grid-cols-4">
+              <p>
                 Funded: <span className="font-semibold text-slate-900">{bounty.fundedPercent}%</span>
-              </div>
-              <div>
+              </p>
+              <p>
                 Claims: <span className="font-semibold text-slate-900">{bounty.claimedCount}</span>
-              </div>
-              <div>
+              </p>
+              <p>
                 Posted: <span className="font-semibold text-slate-900">{bounty.postedDaysAgo}d ago</span>
-              </div>
+              </p>
+              <p>
+                Score: <span className="font-semibold text-brand-700">{bounty.score.toFixed(1)}</span>
+              </p>
             </div>
-            <div className="mt-3 text-xs text-slate-500">
-              Score: <span className="font-semibold text-brand-700">{bounty.score.toFixed(1)}</span>
+
+            <div className="mt-3 space-y-1 text-[11px] text-slate-500">
+              <p>
+                rewardWeight: <span className="font-semibold text-slate-900">{bounty.components.rewardWeight.toFixed(1)}</span>,
+                fundedWeight: <span className="font-semibold text-slate-900">{bounty.components.fundedWeight.toFixed(1)}</span>,
+                claimsWeight: <span className="font-semibold text-slate-900">{bounty.components.claimsWeight.toFixed(1)}</span>,
+                freshnessWeight: <span className="font-semibold text-slate-900">{bounty.components.freshnessWeight.toFixed(1)}</span>
+              </p>
             </div>
           </div>
         ))}

--- a/src/components/bounty-card.tsx
+++ b/src/components/bounty-card.tsx
@@ -1,7 +1,7 @@
 type BountyCardProps = {
   title: string;
   reward: number;
-  tags: string[];
+  tags: readonly string[];
   difficulty: "Easy" | "Medium" | "Hard";
   progress: number;
 };

--- a/src/data/mock-bounties.ts
+++ b/src/data/mock-bounties.ts
@@ -4,7 +4,7 @@ export const mockBounties = [
     title: "Fix mobile overflow on stats cards",
     reward: 120,
     tags: ["frontend", "ux", "bugfix"],
-    difficulty: "Easy",
+    difficulty: "Easy" as const,
     progress: 60,
   },
   {
@@ -12,15 +12,17 @@ export const mockBounties = [
     title: "Add CSV export to leaderboard",
     reward: 250,
     tags: ["data", "dashboard"],
-    difficulty: "Medium",
+    difficulty: "Medium" as const,
     progress: 35,
   },
   {
     id: "bounty-3",
     title: "Improve bounty discovery ranking",
-    reward: 400,
     tags: ["algorithm", "ranking"],
-    difficulty: "Hard",
+    difficulty: "Hard" as const,
+    reward: 400,
     progress: 10,
   },
-];
+] as const;
+
+export type BountyDifficulty = (typeof mockBounties)[number]["difficulty"];


### PR DESCRIPTION
Implemented #3 (Bounty Discovery Algorithm) with a deterministic, weighted scoring model.

## What I changed
- Reworked `/discovery` scoring into a documented helper with explicit components:
  - reward weight
  - funded progress weight
  - active claims weight
  - freshness weight
- Added stable tie-breaker logic (score desc, then reward desc, then recency asc)
- Displayed score breakdown inline for transparency
- Kept UI compact and responsive

## Notes
- Updated mock bounty typing for clearer static typing on difficulty and tags.
- Also fixed minor TS compatibility issue on `/bounty-card` by accepting readonly tag arrays for safer prop mapping.

## Validation
- `npm install && npm run build` passes in local repo.
