### PR TITLE
fix: persist bounty filter state to URL query params (#6)

### DIFF
--- a/src/components/bounty-filter.tsx
+++ b/src/components/bounty-filter.tsx
@@ -1,18 +1,45 @@
 "use client";
 
-import { useState } from "react";
-
-// BUG: Filter state resets on page refresh
-// FIX: Persist to URL query params or localStorage
+import { useState, useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 
 type FilterProps = {
   onFilterChange: (filters: { difficulty: string; minReward: number }) => void;
 };
 
 export function BountyFilter({ onFilterChange }: FilterProps) {
-  // BUG: State is lost on refresh - not persisted
-  const [difficulty, setDifficulty] = useState("all");
-  const [minReward, setMinReward] = useState(0);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Initialize state from URL query params so filters survive page refresh
+  const [difficulty, setDifficulty] = useState(() => {
+    return searchParams.get("difficulty") ?? "all";
+  });
+  const [minReward, setMinReward] = useState(() => {
+    const raw = searchParams.get("minReward");
+    return raw ? Number(raw) : 0;
+  });
+
+  // Track whether we've done the initial URL-based sync
+  const initialSyncDone = useRef(false);
+
+  useEffect(() => {
+    if (!initialSyncDone.current) {
+      // On mount, sync URL params to parent state so filtered results match
+      onFilterChange({ difficulty, minReward });
+      initialSyncDone.current = true;
+    }
+  }, [difficulty, minReward, onFilterChange]);
+
+  // Persist filter changes to URL query params so they survive page refresh
+  useEffect(() => {
+    if (!initialSyncDone.current) return; // skip until initial sync is done
+    const params = new URLSearchParams();
+    if (difficulty !== "all") params.set("difficulty", difficulty);
+    if (minReward > 0) params.set("minReward", String(minReward));
+    const query = params.toString();
+    router.replace(query ? `?${query}` : "/bugs/filter", { scroll: false });
+  }, [difficulty, minReward, router]);
 
   const handleDifficultyChange = (value: string) => {
     setDifficulty(value);
@@ -51,8 +78,8 @@ export function BountyFilter({ onFilterChange }: FilterProps) {
         />
       </div>
 
-      <div className="text-xs text-slate-400">
-        (Bug: refresh the page - filters reset!)
+      <div className="text-xs text-emerald-600">
+        Filters are now persisted in the URL — refresh the page and they stay!
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #6

## Bug Fix Summary

**Issue:** Filter state was lost on page refresh — the BountyFilter component used React useState which resets on refresh, giving users a broken UX where all their filter choices disappeared.

**Root Cause:** State was stored only in component memory (useState) with no persistence mechanism. On every page refresh, the component re-mounted with default values.

**Fix:** Persist filter state to URL query parameters using Next.js useSearchParams and useRouter:

1. **Initialize from URL on mount:** useState(() => searchParams.get('difficulty') ?? 'all') — refreshes restore the exact filter state from the URL
2. **Sync to URL on change:** useEffect calls outer.replace('?difficulty=Medium&minReward=200') whenever filters change — keeps URL in sync without navigation
3. **Initial sync to parent:** on first mount, the component propagates URL-restored filter values to the parent so filtered results match immediately

## Acceptance Criteria Met

- [x] Refresh keeps state (URL is the source of truth)
- [x] Filter changes immediately reflect in the URL
- [x] Filter changes propagate to parent component correctly
- [x] Clearing filters resets to 'all' and removes params from URL

## Testing

1. Go to /bugs/filter
2. Select a difficulty and set min reward
3. Observe URL updates to ?difficulty=Medium&minReward=200
4. Refresh the page — filters remain active
5. Clear filters — URL returns to base path