### PR TITLE
Fix deterministic leaderboard sorting and tied ranks

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test tests/**/*.test.ts"
   },
   "dependencies": {
     "next": "15.1.0",

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -1,7 +1,8 @@
 import { mockLeaderboard } from "@/data/mock-leaderboard";
+import { rankLeaderboardEntries } from "@/lib/leaderboard";
 
 export default function LeaderboardPage() {
-  const sorted = [...mockLeaderboard].sort((a, b) => b.earned - a.earned);
+  const ranked = rankLeaderboardEntries(mockLeaderboard);
 
   return (
     <div className="space-y-6">
@@ -19,12 +20,12 @@ export default function LeaderboardPage() {
           <div>Bounties</div>
           <div>Total Earned</div>
         </div>
-        {sorted.map((dev, index) => (
+        {ranked.map((dev) => (
           <div
             key={dev.id}
             className="grid grid-cols-5 gap-3 px-5 py-4 text-sm border-b border-slate-100 last:border-b-0"
           >
-            <div className="font-semibold">#{index + 1}</div>
+            <div className="font-semibold">#{dev.rank}</div>
             <div className="col-span-2">
               <div className="font-semibold">{dev.name}</div>
               <div className="text-xs text-slate-500">Reputation {dev.reputation}</div>

--- a/src/components/create-bounty-form.tsx
+++ b/src/components/create-bounty-form.tsx
@@ -8,12 +8,18 @@ type CreateBountyFormProps = {
   onSubmit: (bounty: { title: string; reward: number; difficulty: string }) => void;
 };
 
+type FormErrors = {
+  title?: string;
+  reward?: string;
+};
+
 export function CreateBountyForm({ onSubmit }: CreateBountyFormProps) {
   const [title, setTitle] = useState("");
   const [reward, setReward] = useState("");
   const [difficulty, setDifficulty] = useState("Easy");
   const [submitting, setSubmitting] = useState(false);
   const [submissions, setSubmissions] = useState<string[]>([]);
+  const [errors, setErrors] = useState<FormErrors>({});
   const isSubmittingRef = useRef(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -26,19 +32,23 @@ export function CreateBountyForm({ onSubmit }: CreateBountyFormProps) {
 
     try {
       // Validation: check for empty title and negative reward
+      const nextErrors: FormErrors = {};
       if (!title.trim()) {
-        alert("Title is required");
-        isSubmittingRef.current = false;
-        setSubmitting(false);
-        return;
+        nextErrors.title = "Title is required";
       }
+
       const rewardNum = Number(reward);
       if (isNaN(rewardNum) || rewardNum <= 0) {
-        alert("Reward must be a positive number");
+        nextErrors.reward = "Reward must be a positive number";
+      }
+
+      if (Object.keys(nextErrors).length > 0) {
+        setErrors(nextErrors);
         isSubmittingRef.current = false;
         setSubmitting(false);
         return;
       }
+      setErrors({});
 
       // Simulate API delay
       await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -72,7 +82,10 @@ export function CreateBountyForm({ onSubmit }: CreateBountyFormProps) {
           <input
             type="text"
             value={title}
-            onChange={(e) => setTitle(e.target.value)}
+            onChange={(e) => {
+              setTitle(e.target.value);
+              setErrors((prev) => ({ ...prev, title: undefined }));
+            }}
             className="w-full rounded-lg border border-slate-200 px-3 py-2"
             placeholder="Bounty title"
             required
@@ -91,7 +104,10 @@ export function CreateBountyForm({ onSubmit }: CreateBountyFormProps) {
           <input
             type="number"
             value={reward}
-            onChange={(e) => setReward(e.target.value)}
+            onChange={(e) => {
+              setReward(e.target.value);
+              setErrors((prev) => ({ ...prev, reward: undefined }));
+            }}
             className="w-full rounded-lg border border-slate-200 px-3 py-2"
             placeholder="100"
             min="1"

--- a/src/components/leaderboard.tsx
+++ b/src/components/leaderboard.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-// BUG: Sorting algorithm doesn't handle ties correctly
-// When two users have the same earnings, their relative order is inconsistent
-// FIX: Add secondary sort key (e.g., by name or join date)
+import { rankLeaderboardEntries } from "@/lib/leaderboard";
 
 type LeaderboardEntry = {
   id: string;
@@ -23,25 +21,19 @@ const mockLeaderboard: LeaderboardEntry[] = [
 ];
 
 export function Leaderboard() {
-  // BUG: This sort is unstable - tied entries will have inconsistent ordering
-  // The sort only compares by earned, but when earned values are equal,
-  // the result depends on the browser's sort implementation (which may vary)
-  const sorted = [...mockLeaderboard].sort((a, b) => b.earned - a.earned);
+  const ranked = rankLeaderboardEntries(mockLeaderboard);
 
-  // BUG: Rank calculation doesn't account for ties properly
-  // Users with the same earnings should have the same rank
   return (
     <div className="card p-6">
       <h3 className="text-lg font-semibold mb-4">Top Earners</h3>
       <div className="space-y-3">
-        {sorted.map((entry, index) => (
+        {ranked.map((entry) => (
           <div
             key={entry.id}
             className="flex items-center gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100 transition"
           >
-            {/* BUG: Rank is just index+1, doesn't handle ties */}
             <span className="w-8 h-8 flex items-center justify-center rounded-full bg-slate-200 text-sm font-bold">
-              {index + 1}
+              {entry.rank}
             </span>
             <img
               src={entry.avatar}
@@ -66,8 +58,7 @@ export function Leaderboard() {
 
       <div className="mt-4 p-3 bg-amber-50 border border-amber-200 rounded-lg">
         <p className="text-xs text-amber-700">
-          <strong>Bug hint:</strong> Notice how users with $35.00 and $20.00 might appear in different orders on page refresh.
-          Also, shouldn&apos;t tied users have the same rank?
+          Tied earnings now share a rank, with names used as a deterministic secondary sort.
         </p>
       </div>
     </div>

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,0 +1,43 @@
+export type LeaderboardRankable = {
+  id: string;
+  name: string;
+  earned: number;
+};
+
+export type RankedLeaderboardEntry<T extends LeaderboardRankable> = T & {
+  rank: number;
+};
+
+export function sortLeaderboardEntries<T extends LeaderboardRankable>(entries: T[]): T[] {
+  return [...entries].sort((a, b) => {
+    const earnedDiff = b.earned - a.earned;
+    if (earnedDiff !== 0) return earnedDiff;
+
+    const nameDiff = a.name.localeCompare(b.name, undefined, {
+      sensitivity: "base",
+      numeric: true,
+    });
+    if (nameDiff !== 0) return nameDiff;
+
+    return a.id.localeCompare(b.id, undefined, { numeric: true });
+  });
+}
+
+export function rankLeaderboardEntries<T extends LeaderboardRankable>(
+  entries: T[],
+): RankedLeaderboardEntry<T>[] {
+  const sorted = sortLeaderboardEntries(entries);
+  let currentRank = 1;
+
+  return sorted.map((entry, index) => {
+    const previous = index > 0 ? sorted[index - 1] : undefined;
+    if (previous && entry.earned !== previous.earned) {
+      currentRank = index + 1;
+    }
+
+    return {
+      ...entry,
+      rank: currentRank,
+    };
+  });
+}

--- a/tests/leaderboard.test.ts
+++ b/tests/leaderboard.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { rankLeaderboardEntries, sortLeaderboardEntries } from "../src/lib/leaderboard.ts";
+
+const entries = [
+  { id: "3", name: "Charlie", earned: 2000 },
+  { id: "1", name: "Alice", earned: 3500 },
+  { id: "2", name: "Bob", earned: 3500 },
+  { id: "4", name: "Diana", earned: 2000 },
+  { id: "5", name: "Eve", earned: 1000 },
+];
+
+test("sorts by earnings descending and name for deterministic ties", () => {
+  const sorted = sortLeaderboardEntries(entries);
+
+  assert.deepEqual(
+    sorted.map((entry) => entry.name),
+    ["Alice", "Bob", "Charlie", "Diana", "Eve"],
+  );
+});
+
+test("assigns the same rank to equal earnings", () => {
+  const ranked = rankLeaderboardEntries(entries);
+
+  assert.deepEqual(
+    ranked.map((entry) => [entry.name, entry.rank]),
+    [
+      ["Alice", 1],
+      ["Bob", 1],
+      ["Charlie", 3],
+      ["Diana", 3],
+      ["Eve", 5],
+    ],
+  );
+});


### PR DESCRIPTION
Fixes #8.

## Summary
- Extract leaderboard sorting/ranking into a reusable helper
- Sort by earned amount descending, then name/id for deterministic ties
- Assign equal ranks to users with the same earnings
- Add node:test coverage for tie ordering and rank assignment
- Fix an existing form validation TypeScript error that blocked production builds

## Verification
- `npm test`
- `npm run build`

Note: `npm run build` still reports the existing Next.js `<img>` lint warning in `src/components/leaderboard.tsx`, but the build completes successfully.