### PR TITLE
Persist bounty filter state in URL

### DIFF
--- a/src/components/bounty-filter.tsx
+++ b/src/components/bounty-filter.tsx
@@ -1,27 +1,66 @@
 "use client";
 
-import { useState } from "react";
-
-// BUG: Filter state resets on page refresh
-// FIX: Persist to URL query params or localStorage
+import { useEffect, useState } from "react";
 
 type FilterProps = {
   onFilterChange: (filters: { difficulty: string; minReward: number }) => void;
 };
 
+const validDifficulties = new Set(["all", "Easy", "Medium", "Hard"]);
+
+function readFiltersFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const difficultyParam = params.get("difficulty") ?? "all";
+  const minRewardParam = Number(params.get("minReward") ?? 0);
+
+  return {
+    difficulty: validDifficulties.has(difficultyParam) ? difficultyParam : "all",
+    minReward: Number.isFinite(minRewardParam) && minRewardParam > 0 ? minRewardParam : 0,
+  };
+}
+
+function writeFiltersToUrl(filters: { difficulty: string; minReward: number }) {
+  const url = new URL(window.location.href);
+
+  if (filters.difficulty === "all") {
+    url.searchParams.delete("difficulty");
+  } else {
+    url.searchParams.set("difficulty", filters.difficulty);
+  }
+
+  if (filters.minReward > 0) {
+    url.searchParams.set("minReward", String(filters.minReward));
+  } else {
+    url.searchParams.delete("minReward");
+  }
+
+  window.history.replaceState(null, "", url);
+}
+
 export function BountyFilter({ onFilterChange }: FilterProps) {
-  // BUG: State is lost on refresh - not persisted
   const [difficulty, setDifficulty] = useState("all");
   const [minReward, setMinReward] = useState(0);
 
+  useEffect(() => {
+    const filters = readFiltersFromUrl();
+    setDifficulty(filters.difficulty);
+    setMinReward(filters.minReward);
+    onFilterChange(filters);
+  }, [onFilterChange]);
+
   const handleDifficultyChange = (value: string) => {
     setDifficulty(value);
-    onFilterChange({ difficulty: value, minReward });
+    const filters = { difficulty: value, minReward };
+    writeFiltersToUrl(filters);
+    onFilterChange(filters);
   };
 
   const handleMinRewardChange = (value: number) => {
-    setMinReward(value);
-    onFilterChange({ difficulty, minReward: value });
+    const nextMinReward = Number.isFinite(value) && value > 0 ? value : 0;
+    setMinReward(nextMinReward);
+    const filters = { difficulty, minReward: nextMinReward };
+    writeFiltersToUrl(filters);
+    onFilterChange(filters);
   };
 
   return (
@@ -51,9 +90,7 @@ export function BountyFilter({ onFilterChange }: FilterProps) {
         />
       </div>
 
-      <div className="text-xs text-slate-400">
-        (Bug: refresh the page - filters reset!)
-      </div>
+      <div className="text-xs text-slate-400">Filters are saved in the page URL.</div>
     </div>
   );
 }

--- a/src/components/create-bounty-form.tsx
+++ b/src/components/create-bounty-form.tsx
@@ -8,12 +8,18 @@ type CreateBountyFormProps = {
   onSubmit: (bounty: { title: string; reward: number; difficulty: string }) => void;
 };
 
+type FormErrors = {
+  title?: string;
+  reward?: string;
+};
+
 export function CreateBountyForm({ onSubmit }: CreateBountyFormProps) {
   const [title, setTitle] = useState("");
   const [reward, setReward] = useState("");
   const [difficulty, setDifficulty] = useState("Easy");
   const [submitting, setSubmitting] = useState(false);
   const [submissions, setSubmissions] = useState<string[]>([]);
+  const [errors, setErrors] = useState<FormErrors>({});
   const isSubmittingRef = useRef(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -26,19 +32,23 @@ export function CreateBountyForm({ onSubmit }: CreateBountyFormProps) {
 
     try {
       // Validation: check for empty title and negative reward
+      const nextErrors: FormErrors = {};
       if (!title.trim()) {
-        alert("Title is required");
-        isSubmittingRef.current = false;
-        setSubmitting(false);
-        return;
+        nextErrors.title = "Title is required";
       }
+
       const rewardNum = Number(reward);
       if (isNaN(rewardNum) || rewardNum <= 0) {
-        alert("Reward must be a positive number");
+        nextErrors.reward = "Reward must be a positive number";
+      }
+
+      if (Object.keys(nextErrors).length > 0) {
+        setErrors(nextErrors);
         isSubmittingRef.current = false;
         setSubmitting(false);
         return;
       }
+      setErrors({});
 
       // Simulate API delay
       await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -72,7 +82,10 @@ export function CreateBountyForm({ onSubmit }: CreateBountyFormProps) {
           <input
             type="text"
             value={title}
-            onChange={(e) => setTitle(e.target.value)}
+            onChange={(e) => {
+              setTitle(e.target.value);
+              setErrors((prev) => ({ ...prev, title: undefined }));
+            }}
             className="w-full rounded-lg border border-slate-200 px-3 py-2"
             placeholder="Bounty title"
             required
@@ -91,7 +104,10 @@ export function CreateBountyForm({ onSubmit }: CreateBountyFormProps) {
           <input
             type="number"
             value={reward}
-            onChange={(e) => setReward(e.target.value)}
+            onChange={(e) => {
+              setReward(e.target.value);
+              setErrors((prev) => ({ ...prev, reward: undefined }));
+            }}
             className="w-full rounded-lg border border-slate-200 px-3 py-2"
             placeholder="100"
             min="1"


### PR DESCRIPTION
Fixes #6.

## Summary
- Hydrate bounty filters from `difficulty` and `minReward` URL query params
- Update the URL when filter controls change
- Keep default filters out of the URL for cleaner links
- Include the existing minimal form validation compile fix so production build is not blocked by the current `errors` reference

## Verification
- `npm run lint`
- `npm run build`
- Browser check: opened `/bugs/filter?difficulty=Hard&minReward=600`, refreshed, and confirmed the Hard/600 filters and filtered count persisted

Note: lint/build still report the existing Next.js `<img>` warning in `src/components/leaderboard.tsx`, but the build completes successfully.