### PR TITLE
fix: stable sorting with proper tie handling for leaderboard (Fixes #8)

### DIFF
--- a/src/components/leaderboard.tsx
+++ b/src/components/leaderboard.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-// BUG: Sorting algorithm doesn't handle ties correctly
-// When two users have the same earnings, their relative order is inconsistent
-// FIX: Add secondary sort key (e.g., by name or join date)
-
 type LeaderboardEntry = {
   id: string;
   name: string;
@@ -23,13 +19,28 @@ const mockLeaderboard: LeaderboardEntry[] = [
 ];
 
 export function Leaderboard() {
-  // BUG: This sort is unstable - tied entries will have inconsistent ordering
-  // The sort only compares by earned, but when earned values are equal,
-  // the result depends on the browser's sort implementation (which may vary)
-  const sorted = [...mockLeaderboard].sort((a, b) => b.earned - a.earned);
+  // FIX: Stable sort with secondary key (bounties_completed descending, then name ascending)
+  const sorted = [...mockLeaderboard].sort((a, b) => {
+    if (b.earned !== a.earned) return b.earned - a.earned;
+    if (b.bounties_completed !== a.bounties_completed) return b.bounties_completed - a.bounties_completed;
+    return a.name.localeCompare(b.name);
+  });
 
-  // BUG: Rank calculation doesn't account for ties properly
-  // Users with the same earnings should have the same rank
+  // FIX: Calculate rank that handles ties properly
+  // Users with the same earnings share the same rank
+  const ranks: number[] = [];
+  sorted.forEach((entry, index) => {
+    if (index === 0) {
+      ranks.push(1);
+    } else if (entry.earned === sorted[index - 1].earned) {
+      // Same earnings as previous entry = same rank
+      ranks.push(ranks[index - 1]);
+    } else {
+      // Different earnings = rank is position + 1
+      ranks.push(index + 1);
+    }
+  });
+
   return (
     <div className="card p-6">
       <h3 className="text-lg font-semibold mb-4">Top Earners</h3>
@@ -39,9 +50,9 @@ export function Leaderboard() {
             key={entry.id}
             className="flex items-center gap-3 p-3 rounded-lg bg-slate-50 hover:bg-slate-100 transition"
           >
-            {/* BUG: Rank is just index+1, doesn't handle ties */}
+            {/* FIX: Rank handles ties - users with same earnings share rank */}
             <span className="w-8 h-8 flex items-center justify-center rounded-full bg-slate-200 text-sm font-bold">
-              {index + 1}
+              {ranks[index]}
             </span>
             <img
               src={entry.avatar}
@@ -62,13 +73,6 @@ export function Leaderboard() {
             </span>
           </div>
         ))}
-      </div>
-
-      <div className="mt-4 p-3 bg-amber-50 border border-amber-200 rounded-lg">
-        <p className="text-xs text-amber-700">
-          <strong>Bug hint:</strong> Notice how users with $35.00 and $20.00 might appear in different orders on page refresh.
-          Also, shouldn&apos;t tied users have the same rank?
-        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Fixes the sorting logic bug (#8) where leaderboard sorting was unstable when values matched.

## Changes
- Added secondary sort key (bounties_completed descending, then name alphabetical) for deterministic ordering
- Implemented proper rank calculation that handles ties correctly
- Users with the same earnings now share the same rank (e.g., both at rank 2 if they tie)
- Removed the bug hint banner since the issues are resolved

## Cause and Fix

**Cause:** The sort only compared by earned amount. When two users had the same earnings, the order depended on the browser sort implementation (unstable). Rank was simply index+1, which didn't account for ties.

**Fix:** 
1. Added secondary sort keys: bounties_completed (desc), then name (asc) for deterministic ordering
2. Implemented proper rank calculation: users with same earnings share the same rank, next different earnings get position-based rank

## Acceptance Criteria
- Deterministic ordering on every page load
- Tied users share the same rank
- No console errors

Closes #8